### PR TITLE
CIのNodeバージョンをRenovate管理下へ移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.11'
+          node-version-file: package.json
       - run: corepack enable
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.4.0"
   },
+  "engines": {
+    "node": "20.12"
+  },
   "packageManager": "pnpm@9.1.3"
 }


### PR DESCRIPTION
## 概要

GitHub ActionsのNodeバージョンをpackage.jsonへ移動させ、Renovate管理できるよう変更